### PR TITLE
Add 'drag and drop' ordering for gallery images

### DIFF
--- a/includes/admin-post-type.php
+++ b/includes/admin-post-type.php
@@ -711,6 +711,7 @@ function adverts_admin_script() {
     wp_enqueue_style( 'adverts-icons-animate' );
     wp_enqueue_script( 'adverts-admin' );
     wp_enqueue_script( 'adverts-gallery' );
+    wp_enqueue_script( 'jquery-ui-sortable' );
     wp_enqueue_script( 'adverts-auto-numeric' );
     wp_enqueue_script( 'plupload-all' );
     wp_enqueue_script( 'suggest' );

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -176,6 +176,48 @@ function adverts_gallery_update() {
     exit;
 }
 
+
+/**
+ * Updates order of attachments (as JSON) in wp_postmeta table
+ * under the key 'adverts_attachments_order'.
+ *
+ * This function is executed when user changes the order of
+ * images in the gallery using drag and drop, or an image is
+ * added/deleted.
+ *
+ * Action: adverts_gallery_update_order
+ *
+ * @see assets/js/adverts-gallery.js
+ * @since 1.0.13
+ */
+function adverts_gallery_update_order() {
+    if (!check_ajax_referer('adverts-gallery', '_ajax_nonce', false)) {
+        echo json_encode(array(
+            "result" => 0,
+            "error" => __("Invalid Session. Please refresh the page and try again.", "adverts")
+        ));
+
+        exit;
+    }
+
+    $post_id = intval($_POST["post_id"]);
+
+    $dirty_ordered_keys = json_decode(stripslashes($_POST["ordered_keys"]));
+    $length = sizeof($dirty_ordered_keys);
+    $clean_ordered_keys = array();
+
+    for ( $i = 0; $i < $length; $i++ ) {
+        $clean_ordered_keys[$i] = intval($dirty_ordered_keys[$i]);
+    }
+
+    $clean_ordered_keys_json = json_encode($clean_ordered_keys);
+
+    update_post_meta($post_id, 'adverts_attachments_order', $clean_ordered_keys_json);
+
+    echo json_encode( array( "result" => 1 ) );
+    exit;
+}
+
 /**
  * Deletes one gallery attachmenent (image)
  * 

--- a/includes/gallery.php
+++ b/includes/gallery.php
@@ -173,11 +173,14 @@ function adverts_gallery_content( $post = null, $conf = array() ) {
                 'post_status' => 'inherit' 
             ) );
 
+            require_once("functions.php"); // sort_images() is defined in functions.php
+            $children = sort_images($children, $post->ID);
+
             foreach($children as $child) {
                 $data[] = adverts_upload_item_data( $child->ID );
             }
         }
-        
+
     ?>
     
     

--- a/wpadverts.php
+++ b/wpadverts.php
@@ -145,8 +145,8 @@ function adverts_init() {
     wp_register_script( 'adverts-auto-numeric', ADVERTS_URL  .'/assets/js/auto-numeric.js', array( 'jquery' ), "1", true);
     wp_register_script( 'adverts-autocomplete', ADVERTS_URL . '/assets/js/adverts-autocomplete.js', array( 'jquery' ), "1", true);
     wp_register_script( 'adverts-multiselect', ADVERTS_URL . '/assets/js/adverts-multiselect.js', array( 'jquery' ), "2", true);
-    wp_register_script( 'adverts-gallery', ADVERTS_URL . '/assets/js/adverts-gallery.js', array( 'jquery', 'plupload-all' ), "1", true);
-    
+    wp_register_script( 'adverts-gallery', ADVERTS_URL . '/assets/js/adverts-gallery.js', array( 'jquery', 'plupload-all' ), "2", true);
+
     wp_localize_script( 'adverts-auto-numeric', 'adverts_currency', array(
         "aSign" => $currency["sign"], 
         "pSign" => $currency["sign_type"],
@@ -286,6 +286,7 @@ function adverts_init_admin() {
     add_action('wp_ajax_adverts_author_suggest', 'adverts_author_suggest');
     add_action('wp_ajax_adverts_gallery_upload', 'adverts_gallery_upload');
     add_action('wp_ajax_adverts_gallery_update', 'adverts_gallery_update');
+    add_action('wp_ajax_adverts_gallery_update_order', 'adverts_gallery_update_order');
     add_action('wp_ajax_adverts_gallery_delete', 'adverts_gallery_delete');
     add_action('wp_ajax_adverts_show_contact', 'adverts_show_contact');
     add_action('wp_ajax_adverts_delete_tmp', 'adverts_delete_tmp');
@@ -293,6 +294,7 @@ function adverts_init_admin() {
     
     add_action('wp_ajax_nopriv_adverts_gallery_upload', 'adverts_gallery_upload');
     add_action('wp_ajax_nopriv_adverts_gallery_update', 'adverts_gallery_update');
+    add_action('wp_ajax_nopriv_adverts_gallery_update_order', 'adverts_gallery_update_order');
     add_action('wp_ajax_nopriv_adverts_gallery_delete', 'adverts_gallery_delete');
     
     add_action('wp_ajax_nopriv_adverts_show_contact', 'adverts_show_contact');


### PR DESCRIPTION
Hi @gwin thanks for the great WP plugin!

This PR is for ordering gallery images using drag and drop:

![galleryimageorder_gif](https://cloud.githubusercontent.com/assets/23710593/21046381/f9dca884-be4b-11e6-813d-f4cfad87fa04.gif)

It looks like this feature has been [requested in the past](https://wordpress.org/support/topic/change-order-of-images-3/), and I needed the feature also. Sharing my solution in case you are interested.

My approach was to store the order of the images as a JSON string (i.e. the image's `wp_posts` IDs) in the `wp_postmeta` table:

| post_id | meta_key  | meta_value |
|--------|----------- | ------------- |
| 123 | adverts_attachments_order  | [50,51,49,48] |

The `meta_value` is updated whenever the user:
1. Changes the order of images using drag and drop
2. Adds an image
3. Deletes an image

Happy to discuss/make any changes if you are interested in this feature.

Cheers
James


