### PR TITLE
Plupload default settings

### DIFF
--- a/includes/gallery.php
+++ b/includes/gallery.php
@@ -69,6 +69,9 @@ function adverts_gallery_content( $post = null, $conf = array() ) {
         ),
     );
     
+    // Filters the default Plupload settings.
+    $init = apply_filters( 'plupload_init', $init );
+
     wp_enqueue_script( 'image-edit' );
     wp_enqueue_style( 'jcrop' );
     wp_enqueue_style( 'adverts-upload' );

--- a/includes/gallery.php
+++ b/includes/gallery.php
@@ -70,7 +70,7 @@ function adverts_gallery_content( $post = null, $conf = array() ) {
     );
     
     // Filters the default Plupload settings.
-    $init = apply_filters( 'plupload_init', $init );
+    $init = apply_filters( 'adverts_plupload_default_settings', $init );
 
     wp_enqueue_script( 'image-edit' );
     wp_enqueue_style( 'jcrop' );


### PR DESCRIPTION
Added new filter to allow modifying [plupload](https://www.plupload.com/docs/v2/Options) default settings.

Example usage; setup client side resize
```
function filter_adverts_plupload_default_settings(array $defaults) {
    // set values
    $defaults['resize'] = array(
        'width' => 1920,
        'height' => 1080,
        'quality' => 90,
    );
    return $defaults;
}
             
// add wpadverts filter
add_filter('adverts_plupload_default_settings', 'filter_adverts_plupload_default_settings');
```