### PR TITLE
Update list.php

### DIFF
--- a/templates/list.php
+++ b/templates/list.php
@@ -119,3 +119,5 @@
 <?php endif; ?>
 
 <?php endif; ?>
+		    
+<?php do_action( "adverts_sh_list_after", $params ) ?>


### PR DESCRIPTION
add hook after adverts_list template, because sometimes we want to add content after this list in category pages. Its very common practice to add content below category pages for SEO purposes.