### PR TITLE
block_categories hook is depreciated

### DIFF
--- a/blocks/class-block-manager.php
+++ b/blocks/class-block-manager.php
@@ -20,7 +20,7 @@ class Adverts_Block_Manager {
     public function __construct( $path = null ) {
         $this->_path = $path;
         
-        add_filter( 'block_categories', array( $this, "register_block_category" ) );
+        add_filter( 'block_categories_all', array( $this, "register_block_category" ) );
     }
     
     public function register_common_scripts() {


### PR DESCRIPTION
replaced the depreciated block_categories hook with the block_categories_all
See: https://developer.wordpress.org/reference/hooks/block_categories/